### PR TITLE
changed unix memory check from free to available memory

### DIFF
--- a/utilities/elements/batch_compute.m
+++ b/utilities/elements/batch_compute.m
@@ -15,9 +15,8 @@ function mem = pc_mem()
 end
 
 function mem = unix_mem()
-    [~, out] = system('vmstat -s -S M | grep "free memory"');
-    mem = sscanf(out, '%f  free memory');
-    mem = mem * 1024 ^ 2;
+    [~, out] = system('cat /proc/meminfo |grep MemAvailable');
+    mem = sscanf(out, 'MemAvailable: %f');
 end
 
 function mem = mac_mem()


### PR DESCRIPTION
Hi JinghaoLu,

on our system we got a very large `nbatch` which made `idbatch` in `frame_stab()` have more than 1 entry of `0`, resulting in an error when indexing into `m.reg`.
This was caused by `batch_compute()` checking the free memory which happened to be 500 MB. However, on Linux free memory is not available memory. See: https://www.linuxatemyram.com/

Might be related to #25 