### PR TITLE
unix_mem in bytes instead of kilobytes

### DIFF
--- a/utilities/elements/batch_compute.m
+++ b/utilities/elements/batch_compute.m
@@ -16,7 +16,8 @@ end
 
 function mem = unix_mem()
     [~, out] = system('cat /proc/meminfo |grep MemAvailable');
-    mem = sscanf(out, 'MemAvailable: %f');
+    mem = sscanf(out, 'MemAvailable: %f'); % in KiB
+    mem = mem * 1024; % in bytes
 end
 
 function mem = mac_mem()


### PR DESCRIPTION
Hi @JinghaoLu,

I had thought that in your original version unix_mem was in KiB, but now I realised that it's actually in bytes. Sorry for the bug in the recently merged PR. 